### PR TITLE
Changed Status to a string for now

### DIFF
--- a/sogeti-portfolio-api/Models/Consultant.cs
+++ b/sogeti-portfolio-api/Models/Consultant.cs
@@ -5,7 +5,7 @@ namespace sogeti_portfolio_api.Models {
         public string lastName { get; set; }
         public string firstName { get; set; }
         public string secondName { get; set; }
-        public Status status {get;set;}
+        public string status {get;set;}
         public string phone { get; set; }
         public string title { get; set; }
         public string practice { get; set; }


### PR DESCRIPTION
Changed Status to a string because there is no reason for a Status to have a Guid right now since it is confined to two types (ATO/ At Client)